### PR TITLE
Link to docker setup guide on install page 

### DIFF
--- a/docs/hosting/installing.md
+++ b/docs/hosting/installing.md
@@ -26,6 +26,10 @@ This will build the farmOS distribution in a directory called "farm". Point your
 server's webroot to this directory (or move the contents to your server's
 webroot) and open it in a browser to access farmOS.
 
+## Local development
+
+See http://farmos.org/development/docker/
+
 ## Requirements
 
 You will need a web server with all the basic [requirements of Drupal].


### PR DESCRIPTION
I think several people wanting to try out FarmOS before getting involved in development would like to use Docker to install it. Linking to the existing docker page http://farmos.org/development/docker/ from the Hosting/Installation page should be enough to get them started.