### PR TITLE
Update client docs to reflect repo merge

### DIFF
--- a/docs/development/client.md
+++ b/docs/development/client.md
@@ -1,4 +1,4 @@
-# farmOS Client / Native app
+# farmOS Client
 
 Work has begun on a simplified farmOS app that works offline in both browser
 and native app form. It will be installable on Android and iOS devices. The
@@ -6,208 +6,81 @@ goal is to create a fast and focused client app for day-to-day and in-the-field
 record keeping that stores data locally for offline use, and syncs back to a
 farmOS server when internet access is available.
 
-The application is divided into two projects:
+The application consists of the main client, which provides the UI and core
+features, as well as native plugins, which provide specific support for native
+functionality, like the ability to persist data and access the camera.
 
-1. farmOS Client: [https://github.com/farmOS/farmOS-client]
-2. farmOS Native: [https://github.com/farmOS/farmOS-native]
-
-The "client" is where all of the UI and features are built. The "native"
-project wraps that client inside a native app, which can be installed on
-Android/iOS.
+The source code can be found here: [https://github.com/farmOS/farmOS-client]
 
 **This documentation is not complete. It is intended only for informational
 purposes at this time.**
 
 ## Releases
 
-Currently, since the project is in early alpha phase, we only have public 
-releases available via Adobe's [Phone Gap Build] service. If you're interested 
-in signing up for beta releases via the Apple and Android app stores, [sign up 
+Currently, since the project is in early alpha phase, we only have public
+releases available via Adobe's [Phone Gap Build] service. If you're interested
+in signing up for beta releases via the Apple and Android app stores, [sign up
 here].
 
 ## Architecture
-The client essentially represents a UI library; the native repository consumes 
-that library, while also providing the client with the dependencies it needs to 
-be able to run on native devices, via Cordova. Those dependencies are the data 
-and login plugins, which perform data and authentication operations specific to 
-the native environment. The client library is separated from the native 
-implementation in this way is so that the client library can also be consumed 
-by other, browser-based implementations, such as Drupal modules, or standalone 
-single page applications.
-
-### farmos-native
-The native repo currently performs two main functions:
-
-- housing the data and login plugins
-- controlling the Cordova build process
-
-The plugins are already quite self-contained. It seems like a forgone conclusion 
-that at some point we'll want to make them into their own independent libraries. 
-They're actually Vue plugins, which is all that's preventing all Vue-related 
-dependencies (and devDependencies) from being removed from the native repo, so 
-that time might need come sooner rather than later. Anticipating that fact, the 
-data and login plugins are outlined separately below.
-
-Putting the plugins aside for now then, the native repo really becomes quite a 
-spare repository, basically comprised of the following:
-
-- the configuration files and build scripts for npm, Webpack and Cordova
-- a mostly empty `index.html`, which just serves as a target for the build 
-scripts
-- a `main.js` file, which only calls the client library and passes it the 
-plugins as arguments
-
-Being concerned solely with the final build process, it really doesn't contain 
-much essential code of its own, only serving to bring all the necessary 
-dependencies and scripts together in one place. Then all it has to do is call 
-the client library's load function and pass in the dependencies it needs. It's 
-conceivable that the whole thing could be replaced with a Makefile.
-
-### data plugin
-The data plugin supplies the client with methods for storing farmOS data on 
-local disk with WebSQL, and for sending that data to a farmOS server via AJAX 
-and the farmOS REST API.
-
-Specifically, the data plugin is a [Vue plugin], which implements
-
-- Vuex subscribe methods, which 
-    - listen for UI actions and mutations, then 
-    - dispatch actions to the db and http modules;
-- the db Vuex module, consisting of Vuex actions, which implement
-    - WebSQL transactions, then
-    - dispatches actions to the UI's store (eg, to update `logs`' "cached" 
-    status);
-- the http Vuex module, consisting of Vuex actions, which implement
-    - AJAX requests, then
-    - dispatches actions to UI's store (eg, to update `logs`' "synced" status).
-  
-### login plugin
-I need to finish the login plugin's documentation once I've gone through and 
-figured out the authentication process better, and fixed some issues with the 
-way it currently uses Vue mixins, but structurally it's pretty similar to the 
-data plugin. 
-
-The one crucial difference is that it also registers a Vue component, 
-`Login.vue`, on the main Vue instance when it's installed by the client. There's 
-a lot that's not ideal about the login plugin, but how it registers the Vue 
-component could actually be a good model for how other components could be added 
-dynamically to the client's core library, if we wanted to break up the UI itself 
-into separate modules.
-
-### farmos-client
-Compared to the native repo, the client repo has a lot more going on. The 
-primary organizing principle for all this, currently, is the Vue framework 
-itself.
-
-The load function, found in `src/app.js`, is the main entry point. It is 
-basically a thin wrapper for instantiating the main Vue object, and installing 
-any Vue plugins that were passed in as dependencies. It's only a few lines, so 
-perhaps it's easiest to illustrate how it works by including it here in its 
-entirety:
-
-```js
-export default (data, login) => {
-  Vue.use(data, {store, router})
-  if (typeof login !== 'undefined') {
-    Vue.use(login, {router, store})
-  }
-  return new Vue({
-    el: '#app',
-    store,
-    router,
-    components: {App},
-    template: '<App/>'
-  })
-};
-```
-
-Note that the login plugin is optional. Crucially, when the plugins are 
-installed, they must be passed the Vuex store and Vue router. Also, the DOM 
-selector `#app` is hardcoded here as the mount point for the Vue application. 
-In the future, this selector should certainly be parameterized to allow more 
-flexibility. 
-
-Beyond the load function, the client can be summarized as comprising:
-
-- Vue components, which implement
-    - Rendering algorithms, based on current state of the Vuex store
-    - Component methods, which dispatch actions/mutations to the store when DOM 
-    events are triggered
-- The Vuex store, which implements 
-    - a state tree, representing the entire UI state (eg, an array of log 
-      objects)
-    - mutations, which transform the UI state (synchronously)
-    - actions, which 
-        - handle asynchronous requests from the data plugin and components, and 
-        - 'commits' mutations to the store at different stages of those requests
-
+The client is made with [Vue.js] and [Apache Cordova]. It's native plugins are
+actually [Vue plugins]. Initially, the client and its native implementation were maintained as separate libraries. This was done with the aim of being able to
+isolate native functionality in plugins that could be swapped out for
+browser-based plugins. This may not be strictly necessary in the future, but it
+does at least make for good separation of concerns.
 
 ## Development environments
-Currently, a local clone of the farmOS-native repository is required to run a 
-development environment for both the client and native repos; however, you do 
-not need to clone the client repo separately if you're only planning to work on 
-the native repo. So, follow the steps below to set up the native repo's dev 
-environment first, regardless of which you're planning to work on, then proceed 
-to setting up the client environment only if you wish to work on the client.
-
-The first thing of course is to clone the native repo from GitHub, and install 
+The first thing of course is to clone the native repo from GitHub, and install
 the npm dependencies:
 
 ```bash
-$ git clone https://github.com/farmOS/farmOS-native.git
+$ git clone https://github.com/farmOS/farmOS-client.git
 $ cd farmOS-native
 $ npm install
 ```
 
-You should now have all the dependencies you need to run the native app, either 
-in the browser or via one of the platform SDK's. If you're main objective is to 
-develop on the client, you'll probably want to do so in the browser. If you only 
-wish to work on the native repo, it will have already downloaded its own copy of 
-the client repo into its `node_modules` directory, along with all its other 
-dependencies, when you ran `npm install`.
-
 ### Browser
-The browser-based development environment can be started by running the 
+The browser-based development environment can be started by running the
 following command from the project root:
 
 ```bash
 $ npm start
 ```
 
-This will start the Webpack devServer, which will compile a development build 
-and serve it from [http://localhost:8080/]. Changes saved to the files in your 
+This will start the Webpack devServer, which will compile a development build
+and serve it from [http://localhost:8080/]. Changes saved to the files in your
 local repo will be hot reloaded automatically while the devServer is running.
 
 #### Proxying a farmOS Docker container
-By default, when the Webpack devServer starts, it will set up a proxy service, 
-which will route all AJAX requests and responses through `http://localhost:80`, 
-in order to prevent CORS errors. This is assumed to be the address of a local 
-farmOS development server running in a Docker container. This is probably the 
-easiest way to get a development backend up and running, so if you don't already 
-have a sever you can use for testing, see the [full instructions for setting up 
+By default, when the Webpack devServer starts, it will set up a proxy service,
+which will route all AJAX requests and responses through `http://localhost:80`,
+in order to prevent CORS errors. This is assumed to be the address of a local
+farmOS development server running in a Docker container. This is probably the
+easiest way to get a development backend up and running, so if you don't already
+have a sever you can use for testing, see the [full instructions for setting up
 a farmOS Docker container].
 
-If you wish to proxy an address other than `http://localhost:80`, you'll need to 
-change the proxy settings in `farmOS-native/config/index.js`. Set 
-`dev.proxy.target` to the address and port of your farmOS testing server. 
-Restart the devServer and it should now be proxying your new address. It may 
-also be necessary to add new endpoints to the `dev.proxy.context` array as new 
-features are developed and new endpoints on the farmOS server need to be 
-reached. For more information, see the [Webpack documentation on configuring the 
+If you wish to proxy an address other than `http://localhost:80`, you'll need to
+change the proxy settings in `farmOS-native/config/index.js`. Set
+`dev.proxy.target` to the address and port of your farmOS testing server.
+Restart the devServer and it should now be proxying your new address. It may
+also be necessary to add new endpoints to the `dev.proxy.context` array as new
+features are developed and new endpoints on the farmOS server need to be
+reached. For more information, see the [Webpack documentation on configuring the
 proxy middleware].
 
-You will also have to install the Drupal [CORS module] on your farmOS server in 
-order to handle the way the client does authentication (hopefully this will no 
-longer be necessary once we implement OAuth). Once it's installed, go to the 
+You will also have to install the Drupal [CORS module] on your farmOS server in
+order to handle the way the client does authentication (hopefully this will no
+longer be necessary once we implement OAuth). Once it's installed, go to the
 [CORS configuration page] and add the following line to the Domains field:
 
 ```
 *|http://localhost:8080||Content-Type,Authorization,X-Requested-With|true
 ```
 
-Finally, when logging in to the client from the browser, simply leave the URL 
-field blank. The devServer will then interpret all requests as relative links 
-and proxy them accordingly. For some reason login can sometimes fail on the 
+Finally, when logging in to the client from the browser, simply leave the URL
+field blank. The devServer will then interpret all requests as relative links
+and proxy them accordingly. For some reason login can sometimes fail on the
 first attempt, but should succeed on all subsequent attempts.
 
 ### Platform SDK's
@@ -216,43 +89,6 @@ first attempt, but should succeed on all subsequent attempts.
 * [Cordova docs on running the emulator and debugger in XCode]
 
 [//]: <> (TODO: Add a few more details on this once I know more)
-
-### Linking the farmOS-client repository
-If you wish to work on the client repo in development, the first thing you'll 
-want to do is clone it from GitHub and install its dependencies:
-
-```bash
-$ git clone https://github.com/farmOS/farmOS-native.git
-$ cd farmOS-native
-$ npm install
-```
-
-Next, you'll need to direct the native repo to use this local copy of the client 
-library, instead of the copy it downloaded into its own `node_modules` 
-directory. Fortunately, npm provides a helpful little cli tool for just this 
-sort of occasion, [npm-link]. It basically just creates a symbolic link in place 
-of the npm package in the consuming repository's `node_modules`. To use it, 
-first navigate to client library to create a reference to your local copy of 
-the client repo:
-
-```bash
-$ cd path/to/farmOS-client 
-$ npm link
-```
-
-Now, navigate to your local copy of the native repo, to point it to your local 
-copy of the client, and start the dev server there, if you haven't already:
-
-```bash
-$ cd path/to/farmOS-native
-$ npm link farmos-client
-$ npm start
-```
-
-Now whenever you save a change to the client repo, Webpack will automatically 
-detect changes in your local client repository. Changes in the client or the 
-native repo will then trigger the native repo's dev server to hot reload, so you 
-can see the changes in the browser.
 
 ## Native build process
 
@@ -360,7 +196,9 @@ Cordova's [iOS Platform Guide]
 [https://github.com/farmOS/farmOS-native]: https://github.com/farmOS/farmOS-native
 [Phone Gap Build]: https://build.phonegap.com/apps/3295280
 [sign up here]: https://docs.google.com/forms/d/e/1FAIpQLSf0brjVUEKiwG1iw4D386iKgbpw5xQ-YJ3w-1iBdKXO-RyK0g/viewform?usp=sf_link
-[Vue plugin]: https://vuejs.org/v2/guide/plugins.html
+[Vue.js]: https://vuejs.org/
+[Apache Cordova]: https://cordova.apache.org/
+[Vue plugins]: https://vuejs.org/v2/guide/plugins.html
 [http://localhost:8080/]: http://localhost:8080/
 [full instructions for setting up a farmOS Docker container]: /development/docker/
 [Webpack documentation on configuring the proxy middleware]: https://webpack.js.org/configuration/dev-server/#devserver-proxy
@@ -368,7 +206,6 @@ Cordova's [iOS Platform Guide]
 [CORS configuration page]: http://localhost/admin/config/services/cors
 [Cordova docs on running the emulator and debugger in Android Studio]: https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#debugging
 [Cordova docs on running the emulator and debugger in XCode]: https://cordova.apache.org/docs/en/latest/guide/platforms/ios/index.html#debugging
-[npm-link]: https://docs.npmjs.com/cli/link
 [WebView]: https://cordova.apache.org/docs/en/latest/guide/hybrid/webviews/
 [Node]: https://nodejs.org
 [Android Platform Guide]: https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html

--- a/docs/development/client.md
+++ b/docs/development/client.md
@@ -35,7 +35,7 @@ the npm dependencies:
 
 ```bash
 $ git clone https://github.com/farmOS/farmOS-client.git
-$ cd farmOS-native
+$ cd farmOS-client
 $ npm install
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
     - Update Safety: development/update-safety.md
     - Docker: development/docker.md
     - API: development/api.md
-    - Client/Native: development/client.md
+    - Client: development/client.md
 - Community:
     - Contribute: community/contribute.md
     - Monthly Call: community/monthly-call.md


### PR DESCRIPTION
This anticipates renaming the farmOS-native to farmOS-client and moving farmOS-client to the legacy group, per https://github.com/farmOS/farmOS-native/issues/86#issuecomment-465145374.