### PR TITLE
Add documentation for OAuth

### DIFF
--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -155,6 +155,24 @@ resources. The header is an Authorization header with a Bearer token:
 
 #### Refreshing Tokens
 
+The `refresh_token` can be used to retrieve a new `access_token` if the token
+has expired.
+
+It is a one step process:
+
+1. The client sends an authenticated request to the `/oauth2/token`endpoint with
+`grant_type` set to `refresh_token` and includes the `refresh_token`,
+`client_id` and `client_secret` in the request body.
+
+    ```console
+    foo@bar:~$ curl -X POST -H 'Authorization: Bearer ad52c04d26c1002084501d28b59196996f0bd93f' -d 'refresh_token=52e7a0e12e8ddd08b155b3b3ee385687fef01664&grant_type=refresh_token&client_id=farmos_api_client&client_secret=client_secret' http://localhost/oauth2/token
+    {"access_token":"acdbfabb736e42aa301b50fdda95d6b7fd3e7e14","expires_in":"300","token_type":"Bearer","scope":"farmos_restws_access","refresh_token":"b73f4744840498a26f43447d8cf755238bfd391a"} 
+    ```
+   
+   The server responds with an `access_token` and `refresh_token` that can be
+   used in future requests. The previous `access_token` and `refresh_token` will
+   no longer work.
+
 ### OAuth2 Authorization with the farmOS API
 
 #### Authorization in farmOS.py

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -92,6 +92,36 @@ resources. The header is an Authorization header with a Bearer token:
 
 #### Implicit Grant
 
+The Implicit Grant is similar to the Authorization Code Grant but only requires
+two steps. The downside is that it does not provide a `refresh_token` to
+generate new `access_tokens` after their expiration. The entire Authorization
+process must be completed again.
+
+Requesting protected resources is a three step process:
+
+1. First, the client sends a request to the farmOS server `/oauth2/authorize`
+endpoint with `response_type` set to `token`. The server redirects the client to
+an`Authorization` page where the user logs in an authorizes the client access to
+the OAuth Scopes it is requesting.
+        
+        Copy this link to browser:
+        http://localhost/oauth2/authorize?response_type=token&client_id=farmos_api_client&redirect_uri=http://localhost/api/authorized&state=sample_state
+
+2. After the user accepts, the server
+redirects with an `access_token` in the URL Fragment.
+
+        Example redirect url from server:
+        http://localhost/api/authorized#access_token=decf13e124664570ae7d4300990280ac43aeb313&expires_in=300&token_type=Bearer&scope=farmos_restws_access&state=akdsfjalsdfjasdfkk
+
+3. The client sends the `access_token` in the request header to access protected
+resources. The header is an Authorization header with a Bearer token: 
+ `Authorization: Bearer access_token`
+    
+    ```console
+    foo@bar:~$ curl --header "Authorization: Bearer decf13e124664570ae7d4300990280ac43aeb313" http://localhost/farm.json
+    {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", .... 
+    ```
+
 #### Password Credentials Grant
 
 #### Refreshing Tokens

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -32,6 +32,22 @@ user's credentials, which makes it a more secure authentication method.
 
 Read more about the [OAuth 2.0 standards]
 
+OAuth Scopes included with farmOS:
+- `user_access`: This allows full user access to the farmOS server. With this
+scope, a third party can do anything the farmOS user account has permission to
+do.
+- `farm_info`: Allows access to data at `/farm.json`
+
+The core `farm_api` module comes with a `farm_api_development` module that can
+be enabled for testing different OAuth authorization flows. For the purposes
+of documentation, this client is used in below examples. This module defines
+an OAuth client with the following parameters:
+- `client_id` = `farmos_development`
+- `client_secret` = None. This client does not require a `client_secret`
+- `redirect_uri` = `http://localhost/api/authorized` (This is required for the
+Authorization Code Grant)
+
+
 ### Authorization Flows
 
 The [OAuth 2.0 standards] outline 4 [Oauth2 Grant Types] to be used in an OAuth2
@@ -63,7 +79,7 @@ endpoint requesting an `Authorization Code`. The user logs in and authorizes
 the client to have the OAuth Scopes it is requesting.
     
         Copy this link to browser -
-        http://localhost/oauth2/authorize?response_type=code&client_id=farmos_api_client&redirect_uri=http://localhost/api/authorized&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
+        http://localhost/oauth2/authorize?response_type=code&client_id=farmos_development&scope=user_access&redirect_uri=http://localhost/api/authorized&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
    
 2. After the user accepts, the server redirects
 to the `redirect_uri` with an authorization `code` and `state` in the query
@@ -78,8 +94,8 @@ included in the POST body. The client makes a POST request to the
 `/oauth2/token` endpoint to retrieve an `access_token` and `refresh_token`.
 
     ```console
-    foo@bar:~$ curl -X POST -d "grant_type=authorization_code&code=ae4d1381cc67def1c10dc88a19af6ac30d7b5959&client_id=farmos_api_client&client_secret=client_secret&redirect_uri=http://localhost/api/authorized" http://localhost/oauth2/token
-    {"access_token":"3f9212c4a6656f1cd1304e47307927a7c224abb0","expires_in":"10","token_type":"Bearer","scope":"farmos_restws_access","refresh_token":"292810b04d688bfb5c3cee28e45637ec8ef1dd9e"}
+    foo@bar:~$ curl -X POST -d "grant_type=authorization_code&code=ae4d1381cc67def1c10dc88a19af6ac30d7b5959&client_id=farmos_development&redirect_uri=http://localhost/api/authorized" http://localhost/oauth2/token
+    {"access_token":"3f9212c4a6656f1cd1304e47307927a7c224abb0","expires_in":"10","token_type":"Bearer","scope":"user_access","refresh_token":"292810b04d688bfb5c3cee28e45637ec8ef1dd9e"}
     ```
 4. The client sends the access token in the request header to access protected
 resources. The header is an Authorization header with a Bearer token: 
@@ -141,8 +157,8 @@ Requesting protected resources is a two step process:
 endpoint with `grant_type` set to `password` and a `username` and `password`
 included in the request body.
 
-        $ curl -X POST -d "grant_type=password&username=paul&password=test&client_id=farmos_api_client&client_secret=client_secret" http://localhost/oauth2/token
-        {"access_token":"e69c60dea3f5c59c95863928fa6fb860d3506fe9","expires_in":"300","token_type":"Bearer","scope":"farmos_restws_access","refresh_token":"cead7d46d18d74daea83f114bc0b512ec4cc31c3"}
+        $ curl -X POST -d "grant_type=password&username=username&password=test&client_id=farmos_development&scope=user_access" http://localhost/oauth2/token
+        {"access_token":"e69c60dea3f5c59c95863928fa6fb860d3506fe9","expires_in":"300","token_type":"Bearer","scope":"user_access","refresh_token":"cead7d46d18d74daea83f114bc0b512ec4cc31c3"}
 
 2. The client sends the `access_token` in the request header to access protected
 resources. The header is an Authorization header with a Bearer token: 
@@ -166,7 +182,7 @@ It is a one step process:
 
     ```console
     foo@bar:~$ curl -X POST -H 'Authorization: Bearer ad52c04d26c1002084501d28b59196996f0bd93f' -d 'refresh_token=52e7a0e12e8ddd08b155b3b3ee385687fef01664&grant_type=refresh_token&client_id=farmos_api_client&client_secret=client_secret' http://localhost/oauth2/token
-    {"access_token":"acdbfabb736e42aa301b50fdda95d6b7fd3e7e14","expires_in":"300","token_type":"Bearer","scope":"farmos_restws_access","refresh_token":"b73f4744840498a26f43447d8cf755238bfd391a"} 
+    {"access_token":"acdbfabb736e42aa301b50fdda95d6b7fd3e7e14","expires_in":"300","token_type":"Bearer","scope":"user_access","refresh_token":"b73f4744840498a26f43447d8cf755238bfd391a"} 
     ```
    
    The server responds with an `access_token` and `refresh_token` that can be

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -54,6 +54,42 @@ farmOS migrates to Drupal 8 and can use the [simple_oauth] module.
 
 #### Authorization Code Grant
 
+The Authorization Code Grant is most popular for 3rd party client authorization.
+
+Requesting resources is a four step process:
+
+1. First, the client sends a request to the farmOS server `/oauth2/authorize`
+endpoint requesting an `Authorization Code`. The user logs in and authorizes
+the client to have the OAuth Scopes it is requesting.
+    
+        Copy this link to browser -
+        http://localhost/oauth2/authorize?response_type=code&client_id=farmos_api_client&redirect_uri=http://localhost/api/authorized&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
+   
+2. After the user accepts, the server redirects
+to the `redirect_uri` with an authorization `code` and `state` in the query
+parameters.
+
+        Example redirect url from server:
+        http://localhost/api/authorized?code=9eb9442c7a2b011fd59617635cca5421cd089943&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
+        
+3. Copy the `code` and `state` from the URL into the body of a POST request.
+The `grant_type`, `client_id`, `client_secret` and `redirect_uri` must also be
+included in the POST body. The client makes a POST request to the
+`/oauth2/token` endpoint to retrieve an `access_token` and `refresh_token`.
+
+    ```console
+    foo@bar:~$ curl -X POST -d "grant_type=authorization_code&code=ae4d1381cc67def1c10dc88a19af6ac30d7b5959&client_id=farmos_api_client&client_secret=client_secret&redirect_uri=http://localhost/api/authorized" http://localhost/oauth2/token
+    {"access_token":"3f9212c4a6656f1cd1304e47307927a7c224abb0","expires_in":"10","token_type":"Bearer","scope":"farmos_restws_access","refresh_token":"292810b04d688bfb5c3cee28e45637ec8ef1dd9e"}
+    ```
+4. The client sends the access token in the request header to access protected
+resources. The header is an Authorization header with a Bearer token: 
+ `Authorization: Bearer access_token`
+    
+   ```console
+   foo@bar:~$ curl --header "Authorization: Bearer b872daf5827a75495c8194c6bfa4f90cf46c143e" http://localhost/farm.json
+   {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", .... 
+   ```
+
 #### Implicit Grant
 
 #### Password Credentials Grant

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -34,6 +34,32 @@ Read more about the [OAuth 2.0 standards]
 
 ### Authorization Flows
 
+The [OAuth 2.0 standards] outline 4 [Oauth2 Grant Types] to be used in an OAuth2
+Authorization Flow - They are the *Authorization Code, Implicit, Password
+Credentials* and *Client Credentials* Grants. Currently, the farmOS API
+supports all of these grant types except for the **Client Credentials** 
+grant. The **Authorization Code Grant** and **Implicit Grant** are the only
+Authorization Flows recommended by farmOS for use with 3rd party clients. See
+**Refreshing Tokens** for documentation on how to retrieve new `access_tokens`
+after expiration.
+
+**NOTE:** Only use the **Password Grant** if the client can be trusted with a
+farmOS username and password (this is considered *1st party*). The
+**Client Credentials Grant** is often used for machine authentication not
+associated with a user account. Due to limitations with the Drupal 7
+[oauth2_server] module, access tokens provided via the Client Credentials Grant
+cannot be associated with the Drupal Permissions system to access protected
+resources. farmOS will hopefully support the Client Credentials Grant when
+farmOS migrates to Drupal 8 and can use the [simple_oauth] module.
+
+#### Authorization Code Grant
+
+#### Implicit Grant
+
+#### Password Credentials Grant
+
+#### Refreshing Tokens
+
 ### OAuth2 Authorization with the farmOS API
 
 #### Authorization in farmOS.py

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -50,14 +50,14 @@ Authorization Code Grant)
 
 ### Authorization Flows
 
-The [OAuth 2.0 standards] outline 4 [Oauth2 Grant Types] to be used in an OAuth2
+The [OAuth 2.0 standards] outline 5 [Oauth2 Grant Types] to be used in an OAuth2
 Authorization Flow - They are the *Authorization Code, Implicit, Password
-Credentials* and *Client Credentials* Grants. Currently, the farmOS API
-supports all of these grant types except for the **Client Credentials** 
-grant. The **Authorization Code Grant** and **Implicit Grant** are the only
-Authorization Flows recommended by farmOS for use with 3rd party clients. See
-**Refreshing Tokens** for documentation on how to retrieve new `access_tokens`
-after expiration.
+Credentials, Client Credentials* and *Refresh Token* Grants. Currently, the
+farmOS OAuth Server only supports the **Authorization Code**,
+**Password Credentials** and **Refresh Token** grants. The 
+[Authorization Code](#authorization-code-grant) and
+[Refresh Token](#refreshing-tokens) grants are the only Authorization Flows
+recommended by farmOS for use with 3rd party clients.
 
 **NOTE:** Only use the **Password Grant** if the client can be trusted with a
 farmOS username and password (this is considered *1st party*). The
@@ -105,39 +105,7 @@ resources. The header is an Authorization header with a Bearer token:
    foo@bar:~$ curl --header "Authorization: Bearer b872daf5827a75495c8194c6bfa4f90cf46c143e" http://localhost/farm.json
    {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", .... 
    ```
-
-#### Implicit Grant
-
-The Implicit Grant is similar to the Authorization Code Grant but only requires
-two steps. The downside is that it does not provide a `refresh_token` to
-generate new `access_tokens` after their expiration. The entire Authorization
-process must be completed again.
-
-Requesting protected resources is a three step process:
-
-1. First, the client sends a request to the farmOS server `/oauth2/authorize`
-endpoint with `response_type` set to `token`. The server redirects the client to
-an`Authorization` page where the user logs in an authorizes the client access to
-the OAuth Scopes it is requesting.
-        
-        Copy this link to browser:
-        http://localhost/oauth2/authorize?response_type=token&client_id=farmos_api_client&redirect_uri=http://localhost/api/authorized&state=sample_state
-
-2. After the user accepts, the server
-redirects with an `access_token` in the URL Fragment.
-
-        Example redirect url from server:
-        http://localhost/api/authorized#access_token=decf13e124664570ae7d4300990280ac43aeb313&expires_in=300&token_type=Bearer&scope=farmos_restws_access&state=akdsfjalsdfjasdfkk
-
-3. The client sends the `access_token` in the request header to access protected
-resources. The header is an Authorization header with a Bearer token: 
- `Authorization: Bearer access_token`
-    
-    ```console
-    foo@bar:~$ curl --header "Authorization: Bearer decf13e124664570ae7d4300990280ac43aeb313" http://localhost/farm.json
-    {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", .... 
-    ```
-
+   
 #### Password Credentials Grant
 
 **NOTE:** Only use the **Password Grant** if the client can be trusted with a

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -124,6 +124,35 @@ resources. The header is an Authorization header with a Bearer token:
 
 #### Password Credentials Grant
 
+**NOTE:** Only use the **Password Grant** if the client can be trusted with a
+farmOS username and password (this is considered *1st party*).
+
+The Password Credentials Grant uses a farmOS `username` and `password` to 
+retrieve an `access_token` and `refresh_token` in one step. For the user, this
+is the simplest type of *authorization.* Because the client can be trusted with
+their farmOS Credentials, a users `username` and `password` can be collected
+directly into a login form within the client application. These credentials are
+then used (not stored) to request tokens which are used for *authentication* 
+with the farmOS server and retrieving data.
+
+Requesting protected resources is a two step process:
+
+1. First the client sends a POST request to the farmOS server `/oauth2/token`
+endpoint with `grant_type` set to `password` and a `username` and `password`
+included in the request body.
+
+        $ curl -X POST -d "grant_type=password&username=paul&password=test&client_id=farmos_api_client&client_secret=client_secret" http://localhost/oauth2/token
+        {"access_token":"e69c60dea3f5c59c95863928fa6fb860d3506fe9","expires_in":"300","token_type":"Bearer","scope":"farmos_restws_access","refresh_token":"cead7d46d18d74daea83f114bc0b512ec4cc31c3"}
+
+2. The client sends the `access_token` in the request header to access protected
+resources. The header is an Authorization header with a Bearer token: 
+ `Authorization: Bearer access_token`
+    
+    ```console
+    foo@bar:~$ curl --header "Authorization: Bearer e69c60dea3f5c59c95863928fa6fb860d3506fe9" http://localhost/farm.json
+    {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", .... 
+    ```
+
 #### Refreshing Tokens
 
 ### OAuth2 Authorization with the farmOS API

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -21,6 +21,26 @@ specific farmOS URL, username, and password.
 * `[AUTH]` - Authentication parameters for `curl` commands (this will depend on
   the authentication method you choose below).
 
+## OAuth2 Authorization
+
+farmOS includes an OAuth2 Authorization server for providing 3rd party clients 
+access to the farmOS API. Rather than using a user's username and password to
+authenticate, OAuth2 uses access tokens to authenticate users. The access tokens
+are provided to both 1st and 3rd party clients who wish to access a user's 
+protected resources from a server. Clients store the access token instead of the
+user's credentials, which makes it a more secure authentication method.
+
+Read more about the [OAuth 2.0 standards]
+
+### Authorization Flows
+
+### OAuth2 Authorization with the farmOS API
+
+#### Authorization in farmOS.py
+
+#### Authorization in farmOS.js
+
+
 ## Authentication
 
 ### Cookie and Token
@@ -723,3 +743,7 @@ submit a support request on [GitHub] or ask questions in the
 [GitHub]: https://github.com/farmOS/farmOS
 [farmOS chat room]: https://riot.im/app/#/room/#farmOS:matrix.org
 [Unix timestamp]: https://en.wikipedia.org/wiki/Unix_time
+[OAuth 2.0 standards]: https://oauth.net/2/
+[OAuth2 Grant Types]: https://oauth.net/2/grant-types/
+[oauth2_server]: https://www.drupal.org/project/oauth2_server
+[simple_oauth]: https://www.drupal.org/project/simple_oauth/

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -161,6 +161,81 @@ It is a one step process:
 
 #### Authorization in farmOS.py
 
+Support for OAuth was added to [farmOS.py] starting with v0.1.6. To authorize
+and authenticate via OAuth, just supply the required parameters when creating
+a client. The library will know to use an OAuth Password Credentials or 
+Authorization Code flow.
+
+##### Password Credentials Flow:
+
+```python
+farm_client = farmOS(
+    hostname=url,
+    username=farmos_username,
+    password=farmos_password,
+    client_id="farmos_development",
+    scope="user_access",
+    # Supply a profile name so the tokens are saved to config
+    profile_name="farm"
+)
+```
+Running from a Python Console, the `password` can also be omitted and entered
+at runtime. This allows testing without saving a password in plaintext:
+
+```
+>>> from farmOS import farmOS
+>>> farm_client = farmOS(hostname="http://localhost", username=farmos_username, client_id="farmos_development", scope="user_access")
+>>> Warning: Password input may be echoed.
+>>> Enter password: >? MY_PASSWORD
+>>> farm_client.info()
+'name': 'server-name', 'url': 'http://localhost', 'api_version': '1.2', 'user': ....
+```
+
+##### Authorization Code Flow:
+
+It's also possible to run the Authorization Code Flow from the Python console.
+This is great way to test the Authorization process users will go through. The
+console will print a link to navigate to where you sign in to farmOS and 
+complete the authorization process. You then copy the `link` from the page you
+are redirected to back into the console. This supplies the `farm_client` with
+an an authorization `code` that it uses to request an OAuth `token`. 
+
+```python
+>>> farm_client = farmOS(hostname="http://localhost", client_id="farmos_development", scope="user_access")
+Please go here and authorize, http://localhost/oauth2/authorize?response_type=code&client_id=farmos_development&redirect_uri=http%3A%2F%2Flocalhost%2Fapi%2Fauthorized&scope=user_access&state=V9RCDd4yrSWZP8iGXt6qW51sYxsFZs&access_type=offline&prompt=select_account
+Paste the full redirect URL here:>? http://localhost/api/authorized?code=33429f3530e36f4bdf3c2adbbfcd5b7d73e89d5c&state=V9RCDd4yrSWZP8iGXt6qW51sYxsFZs
+
+>>> farm_client.info()
+'name': 'server-name', 'url': 'http://localhost', 'api_version': '1.2', 'user': ....
+```
+
+##### Supplying an existing token:
+
+It can also be useful to create a client with an existing OAuth Token. This is
+possible by supplying the `token` parameter:
+
+```python
+token = {
+    'access_token': "token",
+    'refresh_token': "token",
+}
+
+farm_client = farmOS(
+    hostname=url,
+    client_id=client_id,
+    client_secret=client_secret,
+    scope=scope,
+    token=token,
+)
+```
+
+This is how the [farmOS Aggregator] uses [farmOS.py] to communicate with farmOS
+servers. OAuth tokens are stored in the Aggregator's database instead of
+usernames and passwords. See how this is implemented in code 
+[here](https://github.com/farmOS/farmOS-aggregator/blob/master/backend/app/app/api/utils/farms.py#L195)
+
+
+
 #### Authorization in farmOS.js
 
 
@@ -844,6 +919,8 @@ submit a support request on [GitHub] or ask questions in the
   Most frameworks/languages provide functions for generating/converting
   dates/times to this format. Only Unix timestamps will be accepted by the API.
 
+[farmOS.py]: https://github.com/farmOS/farmOS.py
+[farmOS Aggregator]: https://github.com/farmOS/farmOS-aggregator
 [REST API]: https://en.wikipedia.org/wiki/Representational_state_transfer
 [CRUD]: https://en.wikipedia.org/wiki/Create,_read,_update_and_delete
 [record types]: /development/architecture


### PR DESCRIPTION
Starting a PR that adds OAuth Documentation. We had talked about creating a separate Authorization and Authentication category separate from the API page, but decided to include under `/development/api` for now.