### PR TITLE
Add link to forums in Community menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - Contribute: community/contribute.md
     - Monthly Call: community/monthly-call.md
     - Farms: community/farms.md
+    - Forum: https://farmos.discourse.group/
     - Maintainers: community/maintainers.md
     - Supporters: community/supporters.md
     - Press: community/press.md


### PR DESCRIPTION
**Why?:** Make it easier for folks to find the forum
or get there from any page on farmOS.org

**Testing?:** 
![image](https://user-images.githubusercontent.com/30754460/72031029-fdc38880-323f-11ea-91be-6e02e217080e.png)
