### PR TITLE
Client repo's default branch is now `develop`.

### DIFF
--- a/docs/development/client.md
+++ b/docs/development/client.md
@@ -38,6 +38,12 @@ $ cd farmOS-client
 $ npm install
 ```
 
+Note that the default branch for this repository is `develop`, not `master`;
+`develop` should represent the most current set of complete features that
+are only awaiting further testing before release. You should branch or fork
+off `develop` and submit pull requests to be merged back into it. The 
+`deploy` branch respresents the latest tagged release.
+
 ### Browser
 The browser-based development environment can be started by running the
 following command from the project root:


### PR DESCRIPTION
This is intended to be merged once changes to the branches in farmOS-client have been completed (see https://github.com/farmOS/farmOS-client/issues/326#issuecomment-603386345). It explains to potential contributors that the default branch is not `master` but `develop`, and how to branch off of it when developing and submitting PR's.