### PR TITLE
Update Docker page

### DIFF
--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -74,35 +74,6 @@ volumes:
 
 Do this for both the `db` and `www` container volumes.
 
-#### Persistent volumes
-
-The `docker-compose.development.yml` file defines two Docker volumes that will
-be mounted into the containers from your host directory:
-
-* `./www` - `/var/html/www` from the farmOS application container, which
-  includes the entire farmOS codebase, `settings.php` file (for connecting to
-  the database), and any files that are uploaded/created in farmOS.
-* `./db` - `/var/lib/mysql` from the MariaDB database container, which contains
-  the farmOS database.
-
-Both will be made available within the `farmOS` directory you created initially.
-
-This is where you will be able to access the code for development purposes. It
-is also how your database and files are persisted when the containers are
-destroyed and rebuilt.
-
-#### File ownership
-
-On a Linux host, all the files in `www` will have an owner and group of
-`www-data`. For development purposes, it is recommended that you change the
-owner of everything in the `www` container to your local user. This can be done
-with the following command:
-
-    sudo chown -R ${USER} www
-
-This changes the owner of *everything* in /var/www/html to the currently logged
-in user on the host. But it leaves the group alone (`www-data`).
-
 ### Install farmOS
 
 Once the containers are up and running, you can install farmOS using the Drupal
@@ -132,6 +103,38 @@ In the "Set up database" step of installation, use the following values:
 
 Follow the instructions to continue with the installation and you should be left
 with a fully-functioning farmOS instance running in a Docker container!
+
+### Development workflow
+
+#### Persistent volumes
+
+The `docker-compose.development.yml` file defines two Docker volumes that will
+be mounted into the containers from your host directory:
+
+* `./www` - `/var/html/www` from the farmOS application container, which
+  includes the entire farmOS codebase, `settings.php` file (for connecting to
+  the database), and any files that are uploaded/created in farmOS.
+* `./db` - `/var/lib/mysql` from the MariaDB database container, which contains
+  the farmOS database.
+
+Both will be made available within the `farmOS` directory you created initially.
+
+This is where you will be able to access the code for development purposes. It
+is also how your database and files are persisted when the containers are
+destroyed and rebuilt.
+
+#### File ownership
+
+On a Linux host, all the files in `www` will have an owner and group of
+`www-data`. For development purposes, it is recommended that you change the
+owner of everything in the `www` container to your local user. This can be done
+with the following command:
+
+    sudo chown -R ${USER} www
+
+This changes the owner of *everything* in /var/www/html to the currently logged
+in user on the host. But it leaves the group alone (`www-data`). Just make sure
+to do this _after_ installation has completed.
 
 ### Updating farmOS
 

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -2,15 +2,11 @@
 
 For general information, see [Hosting farmOS with Docker].
 
-## Docker Compose
+## Install Docker and Docker Compose
 
 The recommended approach for local farmOS development in Docker is to use
 [Docker Compose] to run both the farmOS container and the database container
 on your local host.
-
-### Install Docker and Docker Compose
-
-First, install Docker and Docker Compose:
 
 * [Install Docker]
     * On Mac OS X, use "Docker for Mac" (not "Docker Toolbox")
@@ -18,7 +14,7 @@ First, install Docker and Docker Compose:
     * On Linux, follow the directions on docker.com
 * [Install Docker Compose]
 
-### Create containers
+## Create containers
 
 To create the farmOS Docker containers, start by creating a new farmOS directory
 on your host:
@@ -52,7 +48,7 @@ Then you can shut them down and remove the containers with:
 
     sudo docker-compose down
 
-#### Mac Specific Instructions
+### Mac Specific Instructions
 
 Due to [performance issues] with shared volumes in Docker for Mac, it is
 recommended that you add `:delegated` to your volume definitions in
@@ -74,13 +70,13 @@ volumes:
 
 Do this for both the `db` and `www` container volumes.
 
-### Install farmOS
+## Install farmOS
 
 Once the containers are up and running, you can install farmOS using the Drupal
 installer. This is a simple step-by-step process that you will need to go
 through when you first access the site in your browser.
 
-#### Browser address
+### Browser address
 
 If you are running Docker on Linux, you can simply go to `http://localhost` in
 your browser. Otherwise, you may need to look up the IP address of the Docker
@@ -92,7 +88,7 @@ To find the IP address of your farmOS container, use the following command:
 
 Visit the IP address in a browser - you should see the Drupal/farmOS installer.
 
-#### Database setup
+### Database setup
 
 In the "Set up database" step of installation, use the following values:
 
@@ -104,9 +100,9 @@ In the "Set up database" step of installation, use the following values:
 Follow the instructions to continue with the installation and you should be left
 with a fully-functioning farmOS instance running in a Docker container!
 
-### Development workflow
+## Development workflow
 
-#### Persistent volumes
+### Persistent volumes
 
 The `docker-compose.development.yml` file defines two Docker volumes that will
 be mounted into the containers from your host directory:
@@ -123,7 +119,7 @@ This is where you will be able to access the code for development purposes. It
 is also how your database and files are persisted when the containers are
 destroyed and rebuilt.
 
-#### File ownership
+### File ownership
 
 On a Linux host, all the files in `www` will have an owner and group of
 `www-data`. For development purposes, it is recommended that you change the
@@ -136,7 +132,7 @@ This changes the owner of *everything* in /var/www/html to the currently logged
 in user on the host. But it leaves the group alone (`www-data`). Just make sure
 to do this _after_ installation has completed.
 
-### Updating farmOS
+## Updating farmOS
 
 **Important**: these instructions are for updating a *development* environment
 hosted with Docker. If you are running a production environment, see
@@ -144,7 +140,7 @@ hosted with Docker. If you are running a production environment, see
 
 There are two ways to update your development codebase: incremental vs complete.
 
-#### Incremental update
+### Incremental update
 
 An incremental update can be done if the changes are relatively simple. This
 includes commits to the farmOS repository that do not include any of the
@@ -166,7 +162,7 @@ installation profile repository, which is inside `www/profiles/farm`:
     cd www/profiles/farm
     git pull origin 7.x-1.x
 
-#### Complete update
+### Complete update
 
 **Warning**: if you have made any changes to the code inside `www`, they
 will be overwritten by this process. The one exception is the `www/sites`
@@ -216,7 +212,7 @@ overwrite those changes.
 If anything goes wrong during this process, you can restore to the backup you
 created. See "Backup/restore during development" below.
 
-### Backup/restore during development
+## Backup/restore during development
 
 During development, you can create quick snapshots of the database and/or
 codebase from these volume directories. Simply shut down the running containers
@@ -236,9 +232,9 @@ and create tarball(s).
     sudo tar -xzf backup.tar.gz
     sudo docker-compose up -d
 
-### Development Tools
+## Development Tools
 
-#### Drush
+### Drush
 
 [Drush] is a command line shell and Unix scripting interface for Drupal. Drush
 core ships with lots of useful commands for interacting with code like
@@ -271,7 +267,7 @@ Run the following to start a bash session with the new alias and test the
 
 This should display the same list of drush commands.
 
-### (Optional) Configure a Local Https Reverse Proxy
+## (Optional) Configure a Local Https Reverse Proxy
 
 See [Configuring a Local Https Reverse Proxy].
 


### PR DESCRIPTION
This creates a separate "Development workflow" section and moves "Persistent volumes" and "File ownership" after the installation steps. This is primarily because changing file ownership before installation would produce errors.

I'm also going to add a second quick commit to tweak the headings so the ToC displays more of them.