### PR TITLE
Update Docker.md install instructions

### DIFF
--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -92,6 +92,7 @@ Visit the IP address in a browser - you should see the Drupal/farmOS installer.
 
 In the "Set up database" step of installation, use the following values:
 
+* Database type: 'PostgreSQL'
 * Database name: `farm`
 * Database username: `farm`
 * Database password: `farm`


### PR DESCRIPTION
Clarify PostgreSQL selection in the 'Set Up Database' part of installation.  It is NOT the default selection when installing, and can lead to hard-to-diagnose error if left in default selection (MySQL).